### PR TITLE
Added WS281x support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ Many different LED-strips can be used with this program. The only requirement is
 
 I used the [IKEA Dioder](https://www.ikea.com/us/en/catalog/categories/series/25230/) LED-strip which I connected to my Raspberry Pi 3 model B+ by following [this](https://dordnung.de/raspberrypi-ledstrip/) guide.
 
+For information about how to wire and set up WS281X leds you can refer to [this](https://tutorials-raspberrypi.com/connect-control-raspberry-pi-ws2812-rgb-led-strips/) guide but don't run the setup commands there as the required library is now installed by using `pip` rather than the manual way in the guide. You can also find the library used [here](https://github.com/jgarff/rpi_ws281x).
+
 ### Clone/download repository
 When the hardware is set up, you will need to [download](https://github.com/davidkrantz/Colorfy/archive/master.zip) or clone the repository, the latter can be done by typing
 ```
@@ -71,6 +73,8 @@ blue_pin = 24
 [CHROMECAST]
 name = Chromecast Krantz
 ```
+
+To use a WS281X led strip (Neopixels) you need to set the `is_active` value in `config.ini` to `True`, the `led_count` value to the number of leds in your strip and the `led_pin` to the GPIO pin you connected the data input of your led strip to. The other values under `[WS281X]` are optional and set as default.
 
 ### Run it
 1. First you will have to install the needed packages. These are listed in the `requirements.txt` file and *should* be easily installed using `pip` with

--- a/config.ini.default
+++ b/config.ini.default
@@ -5,3 +5,24 @@ blue_pin = 24
 
 [CHROMECAST]
 name = Chromecast Krantz
+
+[WS281X]
+; WS281X LED strip configuration
+; True if you want to use WS281X leds, False to use default leds
+is_active = False
+; Number of leds in the led strip.
+led_count = 300
+; GPIO pin connected to the pixels (18 uses PWM!).
+led_pin = 18
+; (Optional) LED signal frequency in hertz (usually 800khz).
+led_freq_hz = 800000
+; (Optional) DMA channel to use for generating signal (try 10).
+led_dma = 10
+; (Optional) True to invert the signal (when using NPN transistor level shift).
+led_invert = False      
+; (Optional) Set to 0 for darkest and 255 for brightest.
+led_brightness = 100
+; (Optional) set to '1' for GPIOs 13, 19, 41, 45 or 53.
+led_channel = 0    
+
+

--- a/main.py
+++ b/main.py
@@ -4,15 +4,14 @@ import argparse
 import configparser
 from time import sleep
 from led_controller import LEDController
+from ws281x_controller import WS281XController
 from current_spotify_playback import CurrentSpotifyPlayback, NoArtworkException
 from spotify_background_color import SpotifyBackgroundColor
-
 
 CLIENT_ID = os.environ.get('SPOTIPY_CLIENT_ID')
 CLIENT_SECRET = os.environ.get('SPOTIPY_CLIENT_SECRET')
 REDIRECT_URI = os.environ.get('SPOTIPY_REDIRECT_URI')
 REFRESH_TOKEN = os.environ.get('SPOTIPY_REFRESH_TOKEN')
-
 
 def main(k, color_tol, size):
     """Sets the LED-strip to a suitable color for the current artwork.
@@ -31,13 +30,28 @@ def main(k, color_tol, size):
     """
     config = configparser.ConfigParser()
     config.read('config.ini')
-    GPIO_PINS = config['GPIO PINS']
-    red_pin = int(GPIO_PINS['red_pin'])
-    green_pin = int(GPIO_PINS['green_pin'])
-    blue_pin = int(GPIO_PINS['blue_pin'])
+    WS281X = config['WS281X']
+    if WS281X['is_active'] == 'True':
+        LED_COUNT = int(WS281X['led_count'])     
+        LED_PIN = int(WS281X['led_pin'])          
+        LED_BRIGHTNESS = int(WS281X['led_brightness'])     
+        LED_FREQ_HZ = int(WS281X['led_freq_hz'])  
+        LED_DMA = int(WS281X['led_dma'])      
+        LED_INVERT = WS281X['led_invert']
+        LED_CHANNEL = int(WS281X['led_channel'])   
+        if LED_INVERT == 'True':
+            LED_INVERT = True
+        else:
+            LED_INVERT = False 
+        led = WS281XController(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA, LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL)
+    else:
+        GPIO_PINS = config['GPIO PINS']
+        red_pin = int(GPIO_PINS['red_pin'])
+        green_pin = int(GPIO_PINS['green_pin'])
+        blue_pin = int(GPIO_PINS['blue_pin'])
+        led = LEDController(red_pin, green_pin, blue_pin)
     name = config['CHROMECAST']['name']
 
-    led = LEDController(red_pin, green_pin, blue_pin)
     spotify = CurrentSpotifyPlayback(CLIENT_ID, CLIENT_SECRET,
                                      REDIRECT_URI, REFRESH_TOKEN)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ spotipy==2.4.4
 Pillow==5.3.0
 pigpio==1.42
 scikit_learn==0.20.1
+rpi_ws281x==4.2.2

--- a/ws281x_controller.py
+++ b/ws281x_controller.py
@@ -1,0 +1,96 @@
+import numpy as np
+from time import sleep
+import rpi_ws281x as neopixel
+
+class WS281XController():
+    """Controller for WS281X LED-strips connected to a Raspberry Pi.
+
+    Attributes:
+        strip (Adafruit_NeoPixel): The Neopixel led strip object.
+        
+    """
+
+    def __init__(self, led_count=1, led_pin=18, led_freq_hz=800000, led_dma=10, led_invert=False, led_brightness=100, led_channel=0):
+        """Connect to Raspberry Pi and initilize the GPIO pins.
+
+        Args:
+            led_count (int): Number of leds in the led strip.
+            led_pin (int): GPIO pin connected to the pixels (18 uses PWM!).
+            led_freq_hz (int): (Optional) LED signal frequency in hertz (usually 800khz).
+            led_dma (int): (Optional) DMA channel to use for generating signal (try 10).
+            led_invert (bool): (Optional) True to invert the signal (when using NPN transistor level shift).
+            led_brightness (int): (Optional) LED signal frequency in hertz (usually 800khz).
+            led_channel (int): (Optional) set to '1' for GPIOs 13, 19, 41, 45 or 53.
+
+        """
+
+        self.strip = neopixel.Adafruit_NeoPixel(led_count, led_pin, led_freq_hz, led_dma, led_invert, led_brightness, led_channel)
+        self.strip.begin()
+
+    def _linear_gradient(self, start, finish, n=40):
+        """Returns an interpolation between `start` and `finish` color.
+
+        Args:
+            start (list): Start color on the form [R, G, B].
+            finish (list): Finish color on the form [R, G, B].
+            n (int): Number of interpolation points.
+
+        Returns:
+            list: `n` colors evenly spaced between `start` and `finish`.
+
+        """
+        # Initilize a list of the output colors with the starting color
+        rgb_arr = n * [None]
+        rgb_arr[0] = start
+        # Calcuate a color at each evenly spaced value of t from 1 to n
+        for t in range(1, n):
+            # Interpolate RGB vector for color at the current value of t
+            curr_rgb = [int(start[j] + (float(t)/(n-1)) * (finish[j] \
+                - start[j])) for j in range(3)]
+            rgb_arr[t] = curr_rgb
+        return rgb_arr
+
+    def _get_rgb_from_int(self, RGBint):
+        """Returns r,g and b values from 24-bit RGB value.
+
+        Args:
+            RGBint (int): 24-bit integer RGB value
+
+        Returns:
+            tuple: (R, G, B).
+            
+        """
+        b =  RGBint & 255
+        g = (RGBint >> 8) & 255
+        r = (RGBint >> 16) & 255
+        return r, g, b
+
+    def set_color(self, r, g, b, delay=0.05):
+        """Sets a new color using a linear interpolation.
+
+        Args:
+            r (int): The new red value.
+            g (int): The new green value.
+            b (int): The new blue value.
+            delay (float): Delay in seconds between each interpolation
+                color.
+
+        """
+        r_old, g_old, b_old = self.get_color()
+        rgb_list = self._linear_gradient(start=[r_old, g_old, b_old],
+                                        finish=[r, g, b])
+        for r, g, b in rgb_list:
+            for i in range(self.strip.numPixels()):
+                self.strip.setPixelColorRGB(i, r, g, b)
+            self.strip.show()
+            sleep(delay)
+
+    def get_color(self):
+        """Returns the current color.
+
+        Returns:
+            tuple: (R, G, B). The current color.
+
+        """
+        color = self.strip.getPixelColor(1)
+        return self._get_rgb_from_int(color)


### PR DESCRIPTION
Added support for the WS281x types of led strips (Neopixels) using the `rpi_ws281x` library.  The old version should still work exactly the same unless `is_active` is set to `True` under `[WS281X] in `config.ini`.