### PR TITLE
Adding support for WLED devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,4 @@ logs/log.txt
 logs/.DS_Store
 __pycache__/
 *.py[cod]
-/.idea/
-config.py
+venv

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ logs/log.txt
 logs/.DS_Store
 __pycache__/
 *.py[cod]
+/.idea/
+config.py

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ name = Chromecast Krantz
 
 To use a WS281X led strip (Neopixels) you need to set the `is_active` value in `config.ini` to `True`, the `led_count` value to the number of leds in your strip and the `led_pin` to the GPIO pin you connected the data input of your led strip to. The other values under `[WS281X]` are optional and set as default.
 
+To use any [WLED](https://github.com/Aircoookie/WLED) device you just need to set `is_active` to `True` in `config.ini` and provide the IP address of that device. Currently, just one device at a time is supported.
+
 ### Run it
 1. First you will have to install the needed packages. These are listed in the `requirements.txt` file and *should* be easily installed using `pip` with
 ```

--- a/config.ini.default
+++ b/config.ini.default
@@ -24,3 +24,7 @@ led_invert = False
 led_brightness = 100
 ; (Optional) set to '1' for GPIOs 13, 19, 41, 45 or 53.
 led_channel = 0
+
+[WLED]
+is_active = False
+device_ip = http://192.168.xxx.xxx

--- a/main.py
+++ b/main.py
@@ -2,16 +2,14 @@ import os
 import sys
 import argparse
 import configparser
-import config
 from time import sleep
 from current_spotify_playback import CurrentSpotifyPlayback, NoArtworkException
 from spotify_background_color import SpotifyBackgroundColor
 
-
-CLIENT_ID = config.CLIENT_ID
-CLIENT_SECRET = config.CLIENT_SECRET
-REDIRECT_URI = config.REDIRECT_URI
-REFRESH_TOKEN = config.REFRESH_TOKEN
+CLIENT_ID = os.environ.get('SPOTIPY_CLIENT_ID')
+CLIENT_SECRET = os.environ.get('SPOTIPY_CLIENT_SECRET')
+REDIRECT_URI = os.environ.get('SPOTIPY_REDIRECT_URI')
+REFRESH_TOKEN = os.environ.get('SPOTIPY_REFRESH_TOKEN')
 
 def main(k, color_tol, size):
     """Sets the LED-strip to a suitable color for the current artwork.

--- a/main.py
+++ b/main.py
@@ -2,15 +2,16 @@ import os
 import sys
 import argparse
 import configparser
+import config
 from time import sleep
 from current_spotify_playback import CurrentSpotifyPlayback, NoArtworkException
 from spotify_background_color import SpotifyBackgroundColor
 
 
-CLIENT_ID = os.environ.get('SPOTIPY_CLIENT_ID')
-CLIENT_SECRET = os.environ.get('SPOTIPY_CLIENT_SECRET')
-REDIRECT_URI = os.environ.get('SPOTIPY_REDIRECT_URI')
-REFRESH_TOKEN = os.environ.get('SPOTIPY_REFRESH_TOKEN')
+CLIENT_ID = config.CLIENT_ID
+CLIENT_SECRET = config.CLIENT_SECRET
+REDIRECT_URI = config.REDIRECT_URI
+REFRESH_TOKEN = config.REFRESH_TOKEN
 
 def main(k, color_tol, size):
     """Sets the LED-strip to a suitable color for the current artwork.
@@ -30,6 +31,7 @@ def main(k, color_tol, size):
     config = configparser.ConfigParser()
     config.read('config.ini')
     WS281X = config['WS281X']
+    WLED = config['WLED']
     if WS281X['is_active'] == 'True':
         from ws281x_controller import WS281XController
         LED_COUNT = int(WS281X['led_count'])
@@ -45,6 +47,10 @@ def main(k, color_tol, size):
             LED_INVERT = False
         led = WS281XController(LED_COUNT, LED_PIN, LED_FREQ_HZ, LED_DMA,
                                LED_INVERT, LED_BRIGHTNESS, LED_CHANNEL)
+    elif WLED['is_active'] == 'True':
+        from wled_controller import WLEDController
+        wled_device_ip = WLED['device_ip']
+        led = WLEDController(wled_device_ip)
     else:
         from led_controller import LEDController
         GPIO_PINS = config['GPIO PINS']

--- a/main.py
+++ b/main.py
@@ -6,6 +6,7 @@ from time import sleep
 from current_spotify_playback import CurrentSpotifyPlayback, NoArtworkException
 from spotify_background_color import SpotifyBackgroundColor
 
+
 CLIENT_ID = os.environ.get('SPOTIPY_CLIENT_ID')
 CLIENT_SECRET = os.environ.get('SPOTIPY_CLIENT_SECRET')
 REDIRECT_URI = os.environ.get('SPOTIPY_REDIRECT_URI')

--- a/wled_controller.py
+++ b/wled_controller.py
@@ -1,0 +1,30 @@
+import requests
+
+class WLEDController():
+    """Controller for WS281X LED-strips connected to a Raspberry Pi.
+
+    Attributes:
+        strip (Adafruit_NeoPixel): The Neopixel led strip object.
+
+    """
+
+    def __init__(self, ip):
+        self.ip = ip
+        self.wledDeviceAddress = ip + "/win"
+
+    def set_color(self, r, g, b):
+        requests.get(url = self.wledDeviceAddress + "&R=%d&G=%d&B=%d" % (r, g, b))
+
+    def get_color(self):
+        """Returns the current color.
+
+        Returns:
+            tuple: (R, G, B). The current color.
+
+        """
+        r = requests.get(url = self.ip + "/json/state")
+        data = r.json()
+        r = data['seg'][0]['col'][0][0]
+        g = data['seg'][0]['col'][0][1]
+        b = data['seg'][0]['col'][0][2]
+        return r,g,b

--- a/wled_controller.py
+++ b/wled_controller.py
@@ -1,19 +1,28 @@
 import requests
 
 class WLEDController():
-    """Controller for WS281X LED-strips connected to a Raspberry Pi.
+    """Controller for WLED devices.
 
     Attributes:
-        strip (Adafruit_NeoPixel): The Neopixel led strip object.
+        ip (string): The IP address of the WLED device.
 
     """
 
     def __init__(self, ip):
         self.ip = ip
-        self.wledDeviceAddress = ip + "/win"
+        self.wledControlURL = ip + "/win"
+        self.wledStateURL = ip + "/json/state"
 
     def set_color(self, r, g, b):
-        requests.get(url = self.wledDeviceAddress + "&R=%d&G=%d&B=%d" % (r, g, b))
+        """Sets a new color. WLED already smoothly transitions between colors.
+
+        Args:
+            r (int): The new red value.
+            g (int): The new green value.
+            b (int): The new blue value.
+
+        """
+        requests.get(url = self.wledControlURL + "&R=%d&G=%d&B=%d" % (r, g, b))
 
     def get_color(self):
         """Returns the current color.
@@ -22,7 +31,7 @@ class WLEDController():
             tuple: (R, G, B). The current color.
 
         """
-        r = requests.get(url = self.ip + "/json/state")
+        r = requests.get(url = self.wledStateURL)
         data = r.json()
         r = data['seg'][0]['col'][0][0]
         g = data['seg'][0]['col'][0][1]


### PR DESCRIPTION
Hi @davidkrantz 👋 I have not really used this project for a while but with the occasion of Hacktoberfest I thought I might as well raise this PR since I already had the code on my fork. 

I've not been using it because I disconnected the LED strip that was directly wired to my Raspberry Pi and I am now runny a couple of WLED devices using ESP32s. With this setup you can easily control the LED strips with the WLED app and also via the API. I do recommend it if you're still into leds!

For this code change I've followed the pattern of the previous contribution I made and it is quite simple since it only requires a GET request to set the color and one to get the color. WLED already handles the smooth transitions.

Let me know if this looks good 😃 also, would be great if you could add the `hacktoberfest-accepted` label to this PR 


